### PR TITLE
fix(core): resolve circular import in LLM providers module

### DIFF
--- a/agentdock-core/src/llm/providers/index.ts
+++ b/agentdock-core/src/llm/providers/index.ts
@@ -1,19 +1,20 @@
-import {
-  fetchAnthropicModels,
-  fetchCerebrasModels,
-  fetchDeepSeekModels,
-  fetchGeminiModels,
-  fetchGroqModels,
-  fetchOpenAIModels,
-  validateAnthropicApiKey,
-  validateCerebrasApiKey,
-  validateDeepSeekApiKey,
-  validateGeminiApiKey,
-  validateGroqApiKey,
-  validateOpenAIApiKey
-} from '.';
 import { LogCategory, logger } from '../../logging';
 import { LLMProvider, ModelMetadata } from '../types';
+import {
+  fetchAnthropicModels,
+  validateAnthropicApiKey
+} from './anthropic-adapter';
+import {
+  fetchCerebrasModels,
+  validateCerebrasApiKey
+} from './cerebras-adapter';
+import {
+  fetchDeepSeekModels,
+  validateDeepSeekApiKey
+} from './deepseek-adapter';
+import { fetchGeminiModels, validateGeminiApiKey } from './gemini-adapter';
+import { fetchGroqModels, validateGroqApiKey } from './groq-adapter';
+import { fetchOpenAIModels, validateOpenAIApiKey } from './openai-adapter';
 
 /**
  * @fileoverview Provider adapters for LLM providers

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,7 +109,8 @@ export default [
 
       // Import rules
       'import/no-anonymous-default-export': 'warn',
-      'import/no-duplicates': 'error'
+      'import/no-duplicates': 'error',
+      'import/no-cycle': 'error'
     }
   },
 


### PR DESCRIPTION
  - Replace self-import with explicit imports from individual adapter files
  - Add ESLint rule 'import/no-cycle' to prevent future circular dependencies
  - Fixes Node.js module loading failure (ERR_INTERNAL_ASSERTION)