### PR TITLE
feat: add fastCRW node

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Some tools also require their own API keys:
 # Tool-specific API Keys
 SERPER_API_KEY=                  # Required for search functionality
 FIRECRAWL_API_KEY=               # Required for deeper web search
+CRW_API_KEY=                     # Required for fastCRW web scraping (Firecrawl-compatible)
 ```
 
 For more details about environment configuration, see the implementation in [`src/types/env.ts`](src/types/env.ts).

--- a/src/nodes/crw/README.md
+++ b/src/nodes/crw/README.md
@@ -1,0 +1,279 @@
+# CRW (fastCRW) Tools
+
+This set of tools provides comprehensive web interaction capabilities using the [fastCRW](https://fastcrw.com) API. It allows agents to search the web, scrape webpages, crawl websites, map site structures, and extract structured data.
+
+fastCRW is a Firecrawl-compatible web scraper distributed as a single ~8MB binary. You can self-host it (AGPL open core) or use the managed cloud at [fastcrw.com](https://fastcrw.com). Because the API is Firecrawl-compatible, these tools mirror the Firecrawl tools with the fastCRW base URL.
+
+## Configuration
+
+To use these tools, you need to set up the following environment variable:
+
+```
+CRW_API_KEY="your-api-key"
+```
+
+You can get an API key from [fastcrw.com](https://fastcrw.com).
+
+Optionally, you can override the API base URL (for example, to point at a self-hosted instance):
+
+```
+CRW_BASE_URL="https://fastcrw.com/api/v1"
+```
+
+## Available Tools
+
+### 1. CRW Search
+
+Search the web for information on any topic.
+
+#### Parameters
+
+```typescript
+{
+  query: string; // The search query to look up
+  limit?: number; // Maximum number of results to return (default: 5)
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwSearchTool.execute({
+  query: "climate change solutions",
+  limit: 3
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Search Results for "climate change solutions"
+
+**1. [Title of the first result](https://example.com/result1)**
+Snippet text for the first result...
+
+**2. [Title of the second result](https://example.com/result2)**
+Snippet text for the second result...
+
+**3. [Title of the third result](https://example.com/result3)**
+Snippet text for the third result...
+```
+
+### 2. CRW Scrape
+
+Scrape a webpage and extract its content.
+
+#### Parameters
+
+```typescript
+{
+  url: string; // The URL to scrape
+  formats?: string[]; // Formats to return (markdown, html, etc.) (default: ['markdown'])
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwScrapeTool.execute({
+  url: "https://example.com",
+  formats: ["markdown", "html"]
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Scrape Results for [Example Website](https://example.com)
+
+### Metadata
+
+- **Title**: Example Website
+- **Description**: This is an example website
+- **Language**: en
+- **Source URL**: [https://example.com](https://example.com)
+
+### Content Preview
+
+Content of the webpage...
+```
+
+### 3. CRW Crawl
+
+Crawl a website and extract content from multiple pages.
+
+#### Parameters
+
+```typescript
+{
+  url: string; // The URL to crawl
+  limit?: number; // Maximum number of pages to crawl (default: 10)
+  maxDepth?: number; // Maximum crawl depth (default: 2)
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwCrawlTool.execute({
+  url: "https://example.com",
+  limit: 5,
+  maxDepth: 1
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Crawl Results for [Example Website](https://example.com)
+
+**Status**: completed
+**Pages**: 5
+**Crawl ID**: abc-123-xyz
+
+### Pages Found
+
+**1. [Home Page](https://example.com)**
+Content preview...
+
+**2. [About Page](https://example.com/about)**
+Content preview...
+
+...
+```
+
+### 4. CRW Crawl Status
+
+Check the status of a crawl job.
+
+#### Parameters
+
+```typescript
+{
+  crawlId: string; // The crawl job ID to check
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwCrawlStatusTool.execute({
+  crawlId: "abc-123-xyz"
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Crawl Results
+
+**Status**: completed
+**Pages**: 5
+**Crawl ID**: abc-123-xyz
+
+### Pages Found
+
+**1. [Home Page](https://example.com)**
+Content preview...
+
+**2. [About Page](https://example.com/about)**
+Content preview...
+
+...
+```
+
+### 5. CRW Map
+
+Map a website and get a list of all URLs.
+
+#### Parameters
+
+```typescript
+{
+  url: string; // The URL to map
+  maxDepth?: number; // Maximum crawl depth (default: 2)
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwMapTool.execute({
+  url: "https://example.com",
+  maxDepth: 1
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Map Results for [Example Website](https://example.com)
+
+Found **10** URLs on this website.
+
+### URLs Found
+
+1. [https://example.com](https://example.com)
+2. [https://example.com/about](https://example.com/about)
+3. [https://example.com/contact](https://example.com/contact)
+...
+```
+
+### 6. CRW Extract
+
+Extract structured data from a webpage.
+
+#### Parameters
+
+```typescript
+{
+  url: string; // The URL to extract data from
+  prompt?: string; // Prompt to use for extraction
+}
+```
+
+#### Example
+
+```typescript
+const result = await crwExtractTool.execute({
+  url: "https://example.com",
+  prompt: "Extract the company name, founding year, and main products"
+}, { toolCallId: "some-id" });
+```
+
+#### Response Format
+
+```markdown
+## CRW Extract Results for [Example Website](https://example.com)
+
+### Extracted Data
+
+- **company_name**: Example Company
+- **founding_year**: 2005
+- **main_products**: ["Product A", "Product B", "Product C"]
+
+### Metadata
+
+- **Title**: Example Website
+- **Description**: This is an example website
+- **Source URL**: [https://example.com](https://example.com)
+```
+
+## Error Handling
+
+All tools handle various error scenarios:
+
+1. Empty input - Returns an error message asking for non-empty input
+2. Missing configuration - Returns an error if CRW_API_KEY is not set
+3. API errors - Returns a formatted error message with details about the API error
+4. No results - Returns a message indicating no results were found
+
+## Implementation Details
+
+The tools are implemented using three main files:
+
+- `index.ts` - Main tool implementations and exports
+- `components.ts` - UI components for rendering results
+- `utils.ts` - Utility functions for making API calls to fastCRW
+
+The tools follow the Vercel AI SDK patterns and integrate with the AgentDock tool registry.

--- a/src/nodes/crw/components.ts
+++ b/src/nodes/crw/components.ts
@@ -186,11 +186,12 @@ export function CrwScrapeResults(props: CrwScrapeResultsProps) {
  * Renders crawl results in a consistent format
  */
 export function CrwCrawlResults(props: CrwCrawlResultsProps) {
-  // Format the header with the URL
-  const header = formatHeader(
-    `CRW Crawl Results for ${formatLink(props.url, props.url)}`,
-    2
-  );
+  // Format the header with the URL, falling back to the crawl ID when the URL
+  // is missing (e.g. crw_crawl_status passes an empty URL).
+  const crawlTargetLabel = props.url
+    ? formatLink(props.url, props.url)
+    : `crawl ID ${props.result.crawlId}`;
+  const header = formatHeader(`CRW Crawl Results for ${crawlTargetLabel}`, 2);
 
   // Format status information
   const statusInfo = joinSections(

--- a/src/nodes/crw/components.ts
+++ b/src/nodes/crw/components.ts
@@ -1,0 +1,300 @@
+/**
+ * @fileoverview CRW UI components for rendering search results.
+ * These components are used by the crw tool to display information.
+ */
+
+import {
+  createToolResult,
+  formatBold,
+  formatHeader,
+  formatLink,
+  formatListItem,
+  formatSubheader,
+  joinSections
+} from '@/lib/utils/markdown-utils';
+
+/**
+ * Search result interface
+ */
+export interface CrwResult {
+  title: string;
+  url: string;
+  snippet: string;
+  isFeatured?: boolean;
+  isKnowledgeGraph?: boolean;
+}
+
+/**
+ * Scrape result interface
+ */
+export interface CrwScrapeResult {
+  url: string;
+  title: string;
+  content: string;
+  metadata: any;
+}
+
+/**
+ * Crawl result interface
+ */
+export interface CrwCrawlResult {
+  url: string;
+  pages: number;
+  crawlId: string;
+  status: string;
+  results: {
+    url: string;
+    title: string;
+    content: string;
+  }[];
+}
+
+/**
+ * Map result interface
+ */
+export interface CrwMapResult {
+  url: string;
+  urlCount: number;
+  urls: string[];
+}
+
+/**
+ * Extract result interface
+ */
+export interface CrwExtractResult {
+  url: string;
+  title: string;
+  data: any;
+  metadata: any;
+}
+
+/**
+ * Props for the CrwResults component
+ */
+export interface CrwResultsProps {
+  query: string;
+  results: CrwResult[];
+}
+
+/**
+ * Props for the CrwScrapeResults component
+ */
+export interface CrwScrapeResultsProps {
+  url: string;
+  result: CrwScrapeResult;
+}
+
+/**
+ * Props for the CrwCrawlResults component
+ */
+export interface CrwCrawlResultsProps {
+  url: string;
+  result: CrwCrawlResult;
+}
+
+/**
+ * Props for the CrwMapResults component
+ */
+export interface CrwMapResultsProps {
+  url: string;
+  result: CrwMapResult;
+}
+
+/**
+ * Props for the CrwExtractResults component
+ */
+export interface CrwExtractResultsProps {
+  url: string;
+  result: CrwExtractResult;
+}
+
+/**
+ * Formats a single search result as markdown
+ */
+function formatResult(result: CrwResult, index: number): string {
+  const title =
+    result.isFeatured || result.isKnowledgeGraph
+      ? `${result.title} ${result.isFeatured ? '(Featured Snippet)' : '(Knowledge Graph)'}`
+      : result.title;
+
+  const titleLink =
+    result.url !== '#' ? formatLink(title, result.url) : `**${title}**`;
+
+  return `**${index + 1}. ${titleLink}**\n${result.snippet}`;
+}
+
+/**
+ * CRW results component
+ * Renders search results in a consistent format
+ */
+export function CrwResults(props: CrwResultsProps) {
+  // Format the header with the query
+  const header = formatHeader(`CRW Search Results for "${props.query}"`, 2);
+
+  // If no results, return a message
+  if (!props.results || props.results.length === 0) {
+    return createToolResult(
+      'crw_results',
+      joinSections(header, 'No results found. Try a different search query.')
+    );
+  }
+
+  // Format each result
+  const formattedResults = props.results.map(formatResult).join('\n\n');
+
+  // Create the content with header and results
+  const content = joinSections(header, formattedResults);
+
+  // Return the formatted content
+  return createToolResult('crw_results', content);
+}
+
+/**
+ * CRW scrape results component
+ * Renders scrape results in a consistent format
+ */
+export function CrwScrapeResults(props: CrwScrapeResultsProps) {
+  // Format the header with the URL
+  const header = formatHeader(
+    `CRW Scrape Results for ${formatLink(props.result.title, props.result.url)}`,
+    2
+  );
+
+  // Format metadata
+  const metadata = props.result.metadata
+    ? `${formatSubheader('Metadata')}\n\n` +
+      `- **Title**: ${props.result.metadata.title || 'N/A'}\n` +
+      `- **Description**: ${props.result.metadata.description || 'N/A'}\n` +
+      `- **Language**: ${props.result.metadata.language || 'N/A'}\n` +
+      `- **Source URL**: ${formatLink(props.result.metadata.sourceURL || props.result.url, props.result.metadata.sourceURL || props.result.url)}`
+    : '';
+
+  // Format content preview (first 500 characters)
+  const contentPreview = props.result.content
+    ? `${formatSubheader('Content Preview')}\n\n${props.result.content.substring(0, 500)}${props.result.content.length > 500 ? '...' : ''}`
+    : 'No content available.';
+
+  // Create the content with header, metadata, and content preview
+  const content = joinSections(header, metadata, contentPreview);
+
+  // Return the formatted content
+  return createToolResult('crw_scrape_results', content);
+}
+
+/**
+ * CRW crawl results component
+ * Renders crawl results in a consistent format
+ */
+export function CrwCrawlResults(props: CrwCrawlResultsProps) {
+  // Format the header with the URL
+  const header = formatHeader(
+    `CRW Crawl Results for ${formatLink(props.url, props.url)}`,
+    2
+  );
+
+  // Format status information
+  const statusInfo = joinSections(
+    `${formatBold('Status')}: ${props.result.status}`,
+    `${formatBold('Pages')}: ${props.result.pages}`,
+    `${formatBold('Crawl ID')}: ${props.result.crawlId}`
+  );
+
+  // If pending, return status only
+  if (props.result.status === 'pending') {
+    return createToolResult(
+      'crw_crawl_results',
+      joinSections(
+        header,
+        statusInfo,
+        'The crawl is still in progress. You can check the status later using the crawl ID.'
+      )
+    );
+  }
+
+  // Format results
+  const resultsSection =
+    props.result.results && props.result.results.length > 0
+      ? `${formatSubheader('Pages Found')}\n\n` +
+        props.result.results
+          .map(
+            (item, index) =>
+              `${formatBold(`${index + 1}. ${formatLink(item.title, item.url)}`)}\n${item.content}`
+          )
+          .join('\n\n')
+      : 'No pages found.';
+
+  // Create the content with header, status, and results
+  const content = joinSections(header, statusInfo, resultsSection);
+
+  // Return the formatted content
+  return createToolResult('crw_crawl_results', content);
+}
+
+/**
+ * CRW map results component
+ * Renders map results in a consistent format
+ */
+export function CrwMapResults(props: CrwMapResultsProps) {
+  // Format the header with the URL
+  const header = formatHeader(
+    `CRW Map Results for ${formatLink(props.url, props.url)}`,
+    2
+  );
+
+  // Format summary
+  const summary = `Found ${formatBold(props.result.urlCount.toString())} URLs on this website.`;
+
+  // Format URLs
+  const urlsSection =
+    props.result.urls && props.result.urls.length > 0
+      ? `${formatSubheader('URLs Found')}\n\n` +
+        props.result.urls
+          .map((url, index) =>
+            formatListItem(formatLink(url, url), index, true)
+          )
+          .join('\n')
+      : 'No URLs found.';
+
+  // Create the content with header, summary, and URLs
+  const content = joinSections(header, summary, urlsSection);
+
+  // Return the formatted content
+  return createToolResult('crw_map_results', content);
+}
+
+/**
+ * CRW extract results component
+ * Renders extract results in a consistent format
+ */
+export function CrwExtractResults(props: CrwExtractResultsProps) {
+  // Format the header with the URL
+  const header = formatHeader(
+    `CRW Extract Results for ${formatLink(props.result.title, props.result.url)}`,
+    2
+  );
+
+  // Format extracted data
+  const dataSection = props.result.data
+    ? `${formatSubheader('Extracted Data')}\n\n` +
+      Object.entries(props.result.data)
+        .map(
+          ([key, value]) =>
+            `- **${key}**: ${typeof value === 'object' ? JSON.stringify(value) : value}`
+        )
+        .join('\n')
+    : 'No data extracted.';
+
+  // Format metadata
+  const metadata = props.result.metadata
+    ? `${formatSubheader('Metadata')}\n\n` +
+      `- **Title**: ${props.result.metadata.title || 'N/A'}\n` +
+      `- **Description**: ${props.result.metadata.description || 'N/A'}\n` +
+      `- **Source URL**: ${formatLink(props.result.metadata.sourceURL || props.result.url, props.result.metadata.sourceURL || props.result.url)}`
+    : '';
+
+  // Create the content with header, data, and metadata
+  const content = joinSections(header, dataSection, metadata);
+
+  // Return the formatted content
+  return createToolResult('crw_extract_results', content);
+}

--- a/src/nodes/crw/index.ts
+++ b/src/nodes/crw/index.ts
@@ -1,0 +1,534 @@
+/**
+ * @fileoverview CRW tool implementation following Vercel AI SDK patterns.
+ * Provides web search, scraping, crawling, mapping, and extraction functionality using the fastCRW API.
+ *
+ * fastCRW is a Firecrawl-compatible web scraper distributed as a single binary;
+ * self-host (AGPL open core) or use the managed cloud at https://fastcrw.com.
+ */
+
+import { LogCategory, logger } from 'agentdock-core';
+import { z } from 'zod';
+
+import {
+  createToolResult,
+  formatErrorMessage
+} from '@/lib/utils/markdown-utils';
+import { Tool } from '../types';
+import {
+  CrwCrawlResults,
+  CrwExtractResults,
+  CrwMapResults,
+  CrwResults,
+  CrwScrapeResults
+} from './components';
+import {
+  checkCrawlStatus,
+  crawlCrw,
+  extractCrw,
+  mapCrw,
+  scrapeCrw,
+  searchCrw
+} from './utils';
+
+/**
+ * Schema for crw search tool parameters
+ */
+const crwSearchSchema = z.object({
+  query: z.string().describe('Search query to look up'),
+  limit: z
+    .number()
+    .optional()
+    .default(5)
+    .describe('Maximum number of results to return')
+});
+
+/**
+ * Schema for crw scrape tool parameters
+ */
+const crwScrapeSchema = z.object({
+  url: z.string().url().describe('URL to scrape'),
+  formats: z
+    .array(z.string())
+    .optional()
+    .default(['markdown'])
+    .describe('Formats to return (markdown, html, etc.)')
+});
+
+/**
+ * Schema for crw crawl tool parameters
+ */
+const crwCrawlSchema = z.object({
+  url: z.string().url().describe('URL to crawl'),
+  limit: z
+    .number()
+    .optional()
+    .default(10)
+    .describe('Maximum number of pages to crawl'),
+  maxDepth: z.number().optional().default(2).describe('Maximum crawl depth')
+});
+
+/**
+ * Schema for crw crawl status tool parameters
+ */
+const crwCrawlStatusSchema = z.object({
+  crawlId: z.string().describe('Crawl job ID to check')
+});
+
+/**
+ * Schema for crw map tool parameters
+ */
+const crwMapSchema = z.object({
+  url: z.string().url().describe('URL to map'),
+  maxDepth: z.number().optional().default(2).describe('Maximum crawl depth')
+});
+
+/**
+ * Schema for crw extract tool parameters
+ */
+const crwExtractSchema = z.object({
+  url: z.string().url().describe('URL to extract data from'),
+  prompt: z.string().optional().describe('Prompt to use for extraction')
+});
+
+/**
+ * Type inference from schemas
+ */
+type CrwSearchParams = z.infer<typeof crwSearchSchema>;
+type CrwScrapeParams = z.infer<typeof crwScrapeSchema>;
+type CrwCrawlParams = z.infer<typeof crwCrawlSchema>;
+type CrwCrawlStatusParams = z.infer<typeof crwCrawlStatusSchema>;
+type CrwMapParams = z.infer<typeof crwMapSchema>;
+type CrwExtractParams = z.infer<typeof crwExtractSchema>;
+
+/**
+ * CRW search tool implementation
+ */
+export const crwSearchTool: Tool = {
+  name: 'crw_search',
+  description: 'Search the web for information on any topic using fastCRW',
+  parameters: crwSearchSchema,
+  async execute({ query, limit = 5 }, options) {
+    logger.debug(
+      LogCategory.NODE,
+      '[CRW]',
+      `Executing search for query: ${query}`,
+      { toolCallId: options.toolCallId }
+    );
+
+    try {
+      // Validate input
+      if (!query.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty search query provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage(
+            'Error',
+            'Please provide a non-empty search query.'
+          )
+        );
+      }
+
+      // Get actual search results from the API
+      const results = await searchCrw(query, limit);
+
+      // Use our CrwResults component to format the output
+      return CrwResults({
+        query,
+        results
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Search execution error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different query.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to complete search for "${query}": ${errorMessage}`,
+          'Please try again with a different query.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * CRW scrape tool implementation
+ */
+export const crwScrapeTool: Tool = {
+  name: 'crw_scrape',
+  description: 'Scrape a webpage and extract its content using fastCRW',
+  parameters: crwScrapeSchema,
+  async execute({ url, formats = ['markdown'] }, options) {
+    logger.debug(LogCategory.NODE, '[CRW]', `Executing scrape for URL: ${url}`, {
+      toolCallId: options.toolCallId
+    });
+
+    try {
+      // Validate input
+      if (!url.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty URL provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage('Error', 'Please provide a non-empty URL.')
+        );
+      }
+
+      // Get actual scrape results from the API
+      const result = await scrapeCrw(url, formats);
+
+      // Use our CrwScrapeResults component to format the output
+      return CrwScrapeResults({
+        url,
+        result
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Scrape execution error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different URL.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to scrape URL "${url}": ${errorMessage}`,
+          'Please try again with a different URL.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * CRW crawl tool implementation
+ */
+export const crwCrawlTool: Tool = {
+  name: 'crw_crawl',
+  description:
+    'Crawl a website and extract content from multiple pages using fastCRW',
+  parameters: crwCrawlSchema,
+  async execute({ url, limit = 10, maxDepth = 2 }, options) {
+    logger.debug(LogCategory.NODE, '[CRW]', `Executing crawl for URL: ${url}`, {
+      toolCallId: options.toolCallId
+    });
+
+    try {
+      // Validate input
+      if (!url.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty URL provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage('Error', 'Please provide a non-empty URL.')
+        );
+      }
+
+      // Get actual crawl results from the API
+      const result = await crawlCrw(url, limit, maxDepth);
+
+      // Use our CrwCrawlResults component to format the output
+      return CrwCrawlResults({
+        url,
+        result
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Crawl execution error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different URL.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to crawl website "${url}": ${errorMessage}`,
+          'Please try again with a different URL.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * CRW crawl status tool implementation
+ */
+export const crwCrawlStatusTool: Tool = {
+  name: 'crw_crawl_status',
+  description: 'Check the status of a crawl job using fastCRW',
+  parameters: crwCrawlStatusSchema,
+  async execute({ crawlId }, options) {
+    logger.debug(
+      LogCategory.NODE,
+      '[CRW]',
+      `Checking crawl status for ID: ${crawlId}`,
+      { toolCallId: options.toolCallId }
+    );
+
+    try {
+      // Validate input
+      if (!crawlId.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty crawl ID provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage('Error', 'Please provide a non-empty crawl ID.')
+        );
+      }
+
+      // Get actual crawl status from the API
+      const result = await checkCrawlStatus(crawlId);
+
+      // Use our CrwCrawlResults component to format the output
+      return CrwCrawlResults({
+        url: '',
+        result
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Crawl status check error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different crawl ID.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to check crawl status for ID "${crawlId}": ${errorMessage}`,
+          'Please try again with a different crawl ID.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * CRW map tool implementation
+ */
+export const crwMapTool: Tool = {
+  name: 'crw_map',
+  description: 'Map a website and get a list of all URLs using fastCRW',
+  parameters: crwMapSchema,
+  async execute({ url, maxDepth = 2 }, options) {
+    logger.debug(LogCategory.NODE, '[CRW]', `Executing map for URL: ${url}`, {
+      toolCallId: options.toolCallId
+    });
+
+    try {
+      // Validate input
+      if (!url.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty URL provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage('Error', 'Please provide a non-empty URL.')
+        );
+      }
+
+      // Get actual map results from the API
+      const result = await mapCrw(url, maxDepth);
+
+      // Use our CrwMapResults component to format the output
+      return CrwMapResults({
+        url,
+        result
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Map execution error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different URL.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to map website "${url}": ${errorMessage}`,
+          'Please try again with a different URL.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * CRW extract tool implementation
+ */
+export const crwExtractTool: Tool = {
+  name: 'crw_extract',
+  description: 'Extract structured data from a webpage using fastCRW',
+  parameters: crwExtractSchema,
+  async execute({ url, prompt }, options) {
+    logger.debug(
+      LogCategory.NODE,
+      '[CRW]',
+      `Executing extract for URL: ${url}`,
+      { toolCallId: options.toolCallId }
+    );
+
+    try {
+      // Validate input
+      if (!url.trim()) {
+        logger.warn(LogCategory.NODE, '[CRW]', 'Empty URL provided');
+        return createToolResult(
+          'crw_error',
+          formatErrorMessage('Error', 'Please provide a non-empty URL.')
+        );
+      }
+
+      // Get actual extract results from the API
+      const result = await extractCrw(url, undefined, prompt);
+
+      // Use our CrwExtractResults component to format the output
+      return CrwExtractResults({
+        url,
+        result
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[CRW]', 'Extract execution error:', {
+        error
+      });
+
+      // Return a formatted error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorContent: string;
+
+      // Check for specific error types
+      if (errorMessage.includes('API key not found')) {
+        errorContent = formatErrorMessage(
+          'Configuration Error',
+          'The fastCRW service is not properly configured. Please ensure the CRW_API_KEY environment variable is set.',
+          'To fix this issue:\n1. Get an API key from fastcrw.com\n2. Add it to your environment variables as CRW_API_KEY\n3. Restart the application'
+        );
+      } else if (errorMessage.includes('API error')) {
+        errorContent = formatErrorMessage(
+          'API Error',
+          'The fastCRW service encountered an error: ' +
+            errorMessage.split(' - ')[0],
+          'This might be due to:\n- Service unavailable\n- Invalid request\n- Service outage\n\nPlease try again later or with a different URL.'
+        );
+      } else {
+        // Generic error message
+        errorContent = formatErrorMessage(
+          'Error',
+          `Unable to extract data from "${url}": ${errorMessage}`,
+          'Please try again with a different URL.'
+        );
+      }
+
+      return createToolResult('crw_error', errorContent);
+    }
+  }
+};
+
+/**
+ * Export tools for registry
+ */
+export const tools = {
+  crw_search: crwSearchTool,
+  crw_scrape: crwScrapeTool,
+  crw_crawl: crwCrawlTool,
+  crw_crawl_status: crwCrawlStatusTool,
+  crw_map: crwMapTool,
+  crw_extract: crwExtractTool
+};

--- a/src/nodes/crw/index.ts
+++ b/src/nodes/crw/index.ts
@@ -37,6 +37,8 @@ const crwSearchSchema = z.object({
   query: z.string().describe('Search query to look up'),
   limit: z
     .number()
+    .int()
+    .min(1)
     .optional()
     .default(5)
     .describe('Maximum number of results to return')
@@ -61,10 +63,18 @@ const crwCrawlSchema = z.object({
   url: z.string().url().describe('URL to crawl'),
   limit: z
     .number()
+    .int()
+    .min(1)
     .optional()
     .default(10)
     .describe('Maximum number of pages to crawl'),
-  maxDepth: z.number().optional().default(2).describe('Maximum crawl depth')
+  maxDepth: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .default(2)
+    .describe('Maximum crawl depth')
 });
 
 /**
@@ -79,7 +89,13 @@ const crwCrawlStatusSchema = z.object({
  */
 const crwMapSchema = z.object({
   url: z.string().url().describe('URL to map'),
-  maxDepth: z.number().optional().default(2).describe('Maximum crawl depth')
+  maxDepth: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .default(2)
+    .describe('Maximum crawl depth')
 });
 
 /**

--- a/src/nodes/crw/utils.ts
+++ b/src/nodes/crw/utils.ts
@@ -1,0 +1,512 @@
+/**
+ * @fileoverview Utility functions for the crw tool.
+ * Contains functions for making API calls to the fastCRW API.
+ *
+ * fastCRW is a Firecrawl-compatible web scraper available as a single binary;
+ * self-host or use the managed cloud. Because the API is Firecrawl-compatible,
+ * this mirrors the Firecrawl provider with the fastCRW base URL.
+ */
+
+import { LogCategory, logger } from 'agentdock-core';
+
+import { cleanText, cleanUrl } from '@/lib/utils/markdown-utils';
+import {
+  CrwCrawlResult,
+  CrwExtractResult,
+  CrwMapResult,
+  CrwResult,
+  CrwScrapeResult
+} from './components';
+
+/**
+ * CRW API client
+ * Talks to the Firecrawl-compatible fastCRW REST API.
+ */
+class CrwClient {
+  private apiKey: string;
+  private baseUrl: string = 'https://fastcrw.com/api/v1';
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey || process.env.CRW_API_KEY || '';
+
+    if (!this.apiKey) {
+      logger.warn(
+        LogCategory.NODE,
+        '[CrwAPI]',
+        'No API key provided, using environment variable'
+      );
+    }
+
+    // Override base URL if specified in environment (e.g. self-hosted instance)
+    if (process.env.CRW_BASE_URL) {
+      this.baseUrl = process.env.CRW_BASE_URL;
+    }
+  }
+
+  /**
+   * Make an API request to CRW
+   */
+  private async request(
+    endpoint: string,
+    method: string = 'POST',
+    body?: any
+  ): Promise<any> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json'
+    };
+
+    // Add authorization header if API key is available
+    if (this.apiKey) {
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
+
+    const options: RequestInit = {
+      method,
+      headers,
+      cache: 'no-store' // Ensure fresh results
+    };
+
+    if (body) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        LogCategory.NODE,
+        '[CrwAPI]',
+        `API error: ${response.status}`,
+        { error: errorText }
+      );
+      throw new Error(
+        `CRW API error: ${response.status} - ${errorText.substring(0, 100)}`
+      );
+    }
+
+    return await response.json();
+  }
+
+  /**
+   * Search the web using CRW
+   */
+  async search(
+    query: string,
+    options: {
+      limit?: number;
+      lang?: string;
+      country?: string;
+      scrapeOptions?: {
+        formats?: string[];
+      };
+    } = {}
+  ): Promise<any> {
+    logger.debug(LogCategory.NODE, '[CrwAPI]', `Searching for: ${query}`);
+
+    const body = {
+      query,
+      limit: options.limit || 25,
+      lang: options.lang || 'en',
+      country: options.country || 'us',
+      scrapeOptions: options.scrapeOptions || { formats: ['markdown'] }
+    };
+
+    return this.request('/search', 'POST', body);
+  }
+
+  /**
+   * Scrape a URL using CRW
+   */
+  async scrape(
+    url: string,
+    options: {
+      formats?: string[];
+      jsonOptions?: {
+        schema?: any;
+        prompt?: string;
+      };
+    } = {}
+  ): Promise<any> {
+    logger.debug(LogCategory.NODE, '[CrwAPI]', `Scraping URL: ${url}`);
+
+    const body = {
+      url,
+      formats: options.formats || ['markdown'],
+      jsonOptions: options.jsonOptions
+    };
+
+    return this.request('/scrape', 'POST', body);
+  }
+
+  /**
+   * Crawl a website using CRW
+   */
+  async crawl(
+    url: string,
+    options: {
+      limit?: number;
+      maxDepth?: number;
+      excludePaths?: string[];
+      includePaths?: string[];
+      scrapeOptions?: {
+        formats?: string[];
+      };
+    } = {}
+  ): Promise<any> {
+    logger.debug(LogCategory.NODE, '[CrwAPI]', `Crawling website: ${url}`);
+
+    const body = {
+      url,
+      limit: options.limit || 10,
+      maxDepth: options.maxDepth || 2,
+      excludePaths: options.excludePaths || [],
+      includePaths: options.includePaths || [],
+      scrapeOptions: options.scrapeOptions || { formats: ['markdown'] }
+    };
+
+    return this.request('/crawl', 'POST', body);
+  }
+
+  /**
+   * Check crawl status
+   */
+  async checkCrawlStatus(id: string): Promise<any> {
+    logger.debug(LogCategory.NODE, '[CrwAPI]', `Checking crawl status: ${id}`);
+    return this.request(`/crawl/${id}`, 'GET');
+  }
+
+  /**
+   * Map a website using CRW
+   */
+  async map(
+    url: string,
+    options: {
+      maxDepth?: number;
+      excludePaths?: string[];
+      includePaths?: string[];
+    } = {}
+  ): Promise<any> {
+    logger.debug(LogCategory.NODE, '[CrwAPI]', `Mapping website: ${url}`);
+
+    const body = {
+      url,
+      maxDepth: options.maxDepth || 2,
+      excludePaths: options.excludePaths || [],
+      includePaths: options.includePaths || []
+    };
+
+    return this.request('/map', 'POST', body);
+  }
+
+  /**
+   * Extract structured data from a URL using CRW
+   */
+  async extract(
+    url: string,
+    options: {
+      schema?: any;
+      prompt?: string;
+    } = {}
+  ): Promise<any> {
+    logger.debug(
+      LogCategory.NODE,
+      '[CrwAPI]',
+      `Extracting data from URL: ${url}`
+    );
+
+    const body = {
+      url,
+      formats: ['json'],
+      jsonOptions: {
+        schema: options.schema,
+        prompt: options.prompt
+      }
+    };
+
+    return this.request('/scrape', 'POST', body);
+  }
+}
+
+// Create a singleton instance of the CRW client
+const crwClient = new CrwClient();
+
+/**
+ * Performs a web search using the CRW API
+ * @param query The search query
+ * @param limit Maximum number of results to return
+ * @returns Array of search results
+ */
+export async function searchCrw(
+  query: string,
+  limit: number = 25
+): Promise<CrwResult[]> {
+  try {
+    const response = await crwClient.search(query, { limit });
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unknown error');
+    }
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Search results received', {
+      resultsCount: response.data?.length || 0
+    });
+
+    // Transform API response to our CrwResult format
+    const results: CrwResult[] = [];
+
+    // Process results
+    if (response.data && Array.isArray(response.data)) {
+      for (const item of response.data) {
+        if (results.length >= limit) break;
+
+        // Skip results without a URL or with empty content
+        if (!item.url || (!item.title && !item.description)) continue;
+
+        results.push({
+          title: cleanText(item.title) || 'No title',
+          url: cleanUrl(item.url),
+          snippet:
+            cleanText(
+              item.description ||
+                (item.markdown ? item.markdown.substring(0, 200) + '...' : '')
+            ) || 'No description available.'
+        });
+      }
+    }
+
+    // If we still don't have enough results, add a message
+    if (results.length === 0) {
+      logger.warn(
+        LogCategory.NODE,
+        '[CrwAPI]',
+        'No valid search results found for query',
+        { query }
+      );
+      results.push({
+        title: 'No results found',
+        url: '#',
+        snippet: `No search results were found for "${query}". Try a different search query.`
+      });
+    }
+
+    // Limit to requested number
+    return results.slice(0, limit);
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Search error:', {
+      error
+    });
+    throw error;
+  }
+}
+
+/**
+ * Scrapes a URL using the CRW API
+ * @param url The URL to scrape
+ * @param formats The formats to return (markdown, html, etc.)
+ * @returns Scrape result
+ */
+export async function scrapeCrw(
+  url: string,
+  formats: string[] = ['markdown']
+): Promise<CrwScrapeResult> {
+  try {
+    const response = await crwClient.scrape(url, { formats });
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unknown error');
+    }
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Scrape result received', {
+      url
+    });
+
+    return {
+      url: url,
+      title: response.data?.metadata?.title || 'No title',
+      content: response.data?.markdown || 'No content available.',
+      metadata: response.data?.metadata || {}
+    };
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Scrape error:', {
+      error
+    });
+    throw error;
+  }
+}
+
+/**
+ * Crawls a website using the CRW API
+ * @param url The URL to crawl
+ * @param limit Maximum number of pages to crawl
+ * @param maxDepth Maximum crawl depth
+ * @returns Crawl result
+ */
+export async function crawlCrw(
+  url: string,
+  limit: number = 10,
+  maxDepth: number = 2
+): Promise<CrwCrawlResult> {
+  try {
+    const response = await crwClient.crawl(url, {
+      limit,
+      maxDepth,
+      scrapeOptions: { formats: ['markdown'] }
+    });
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unknown error');
+    }
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Crawl job submitted', {
+      url,
+      crawlId: response.id
+    });
+
+    // For synchronous crawls, we might get data directly
+    if (response.data) {
+      return {
+        url: url,
+        pages: response.data.length,
+        crawlId: response.id,
+        status: 'completed',
+        results: response.data.map((item: any) => ({
+          url: item.metadata?.sourceURL || '#',
+          title: item.metadata?.title || 'No title',
+          content:
+            item.markdown?.substring(0, 200) + '...' || 'No content available.'
+        }))
+      };
+    }
+
+    // For asynchronous crawls, we return the job ID
+    return {
+      url: url,
+      pages: 0,
+      crawlId: response.id,
+      status: 'pending',
+      results: []
+    };
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Crawl error:', { error });
+    throw error;
+  }
+}
+
+/**
+ * Checks the status of a crawl job
+ * @param crawlId The crawl job ID
+ * @returns Crawl result
+ */
+export async function checkCrawlStatus(
+  crawlId: string
+): Promise<CrwCrawlResult> {
+  try {
+    const response = await crwClient.checkCrawlStatus(crawlId);
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Crawl status received', {
+      crawlId,
+      status: response.status,
+      completed: response.completed,
+      total: response.total
+    });
+
+    return {
+      url: '',
+      pages: response.total || 0,
+      crawlId: crawlId,
+      status: response.status,
+      results: (response.data || []).map((item: any) => ({
+        url: item.metadata?.sourceURL || '#',
+        title: item.metadata?.title || 'No title',
+        content:
+          item.markdown?.substring(0, 200) + '...' || 'No content available.'
+      }))
+    };
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Check crawl status error:', {
+      error
+    });
+    throw error;
+  }
+}
+
+/**
+ * Maps a website using the CRW API
+ * @param url The URL to map
+ * @param maxDepth Maximum crawl depth
+ * @returns Map result
+ */
+export async function mapCrw(
+  url: string,
+  maxDepth: number = 2
+): Promise<CrwMapResult> {
+  try {
+    const response = await crwClient.map(url, { maxDepth });
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unknown error');
+    }
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Map result received', {
+      url,
+      urlCount: response.data?.urls?.length || 0
+    });
+
+    return {
+      url: url,
+      urlCount: response.data?.urls?.length || 0,
+      urls: response.data?.urls || []
+    };
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Map error:', { error });
+    throw error;
+  }
+}
+
+/**
+ * Extracts structured data from a URL using the CRW API
+ * @param url The URL to extract data from
+ * @param schema The schema to extract (optional)
+ * @param prompt The prompt to use for extraction (optional)
+ * @returns Extract result
+ */
+export async function extractCrw(
+  url: string,
+  schema?: any,
+  prompt?: string
+): Promise<CrwExtractResult> {
+  try {
+    const options: any = {};
+
+    if (schema) {
+      options.schema = schema;
+    } else if (prompt) {
+      options.prompt = prompt;
+    }
+
+    const response = await crwClient.extract(url, options);
+
+    if (!response.success) {
+      throw new Error(response.error || 'Unknown error');
+    }
+
+    logger.debug(LogCategory.NODE, '[CrwAPI]', 'Extract result received', {
+      url
+    });
+
+    return {
+      url: url,
+      title: response.data?.metadata?.title || 'No title',
+      data: response.data?.json || {},
+      metadata: response.data?.metadata || {}
+    };
+  } catch (error) {
+    logger.error(LogCategory.NODE, '[CrwAPI]', 'Extract error:', {
+      error
+    });
+    throw error;
+  }
+}

--- a/src/nodes/crw/utils.ts
+++ b/src/nodes/crw/utils.ts
@@ -375,8 +375,9 @@ export async function crawlCrw(
         results: response.data.map((item: any) => ({
           url: item.metadata?.sourceURL || '#',
           title: item.metadata?.title || 'No title',
-          content:
-            item.markdown?.substring(0, 200) + '...' || 'No content available.'
+          content: item.markdown
+            ? `${item.markdown.substring(0, 200)}...`
+            : 'No content available.'
         }))
       };
     }
@@ -421,8 +422,9 @@ export async function checkCrawlStatus(
       results: (response.data || []).map((item: any) => ({
         url: item.metadata?.sourceURL || '#',
         title: item.metadata?.title || 'No title',
-        content:
-          item.markdown?.substring(0, 200) + '...' || 'No content available.'
+        content: item.markdown
+          ? `${item.markdown.substring(0, 200)}...`
+          : 'No content available.'
       }))
     };
   } catch (error) {

--- a/src/nodes/registry.ts
+++ b/src/nodes/registry.ts
@@ -8,6 +8,7 @@
 import { LogCategory, logger } from 'agentdock-core';
 
 import { tools as cognitiveTools } from './cognitive-tools';
+import { tools as crwTools } from './crw';
 import { cryptoPriceTool, trendingCryptosTool } from './crypto-price';
 import { tools as deepResearchTools } from './deep-research';
 import { tools as firecrawlTools } from './firecrawl';
@@ -26,6 +27,7 @@ export const allTools: ToolCollection = {
   ...searchTools,
   ...deepResearchTools,
   ...firecrawlTools,
+  ...crwTools,
   ...snowtracerTools,
   ...imageGenerationTools,
   ...cognitiveTools,

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -30,6 +30,7 @@ const envSchema = z.object({
   // Other API keys
   SERPER_API_KEY: z.string().min(1).optional(),
   FIRECRAWL_API_KEY: z.string().min(1).optional(),
+  CRW_API_KEY: z.string().min(1).optional(),
   ALPHAVANTAGE_API_KEY: z.string().min(1).optional(),
 
   // Application configuration
@@ -64,6 +65,7 @@ export function getEnvConfig(): EnvConfig {
       // Other API keys
       SERPER_API_KEY: process.env.SERPER_API_KEY,
       FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY,
+      CRW_API_KEY: process.env.CRW_API_KEY,
       ALPHAVANTAGE_API_KEY: process.env.ALPHAVANTAGE_API_KEY,
 
       // Application configuration
@@ -85,6 +87,7 @@ export function getEnvConfig(): EnvConfig {
       GROQ_API_KEY: process.env.GROQ_API_KEY,
       SERPER_API_KEY: process.env.SERPER_API_KEY,
       FIRECRAWL_API_KEY: process.env.FIRECRAWL_API_KEY,
+      CRW_API_KEY: process.env.CRW_API_KEY,
       ALPHAVANTAGE_API_KEY: process.env.ALPHAVANTAGE_API_KEY,
       NODE_ENV: process.env.NODE_ENV as any,
       FALLBACK_API_KEY: process.env.FALLBACK_API_KEY,


### PR DESCRIPTION
## What
Adds a **fastCRW** node, alongside the existing Firecrawl node.

New `src/nodes/crw/`, registered in `registry.ts`.

## Why
[fastCRW](https://fastcrw.com) is a fully open-source (AGPL) web scraping engine that outperforms Firecrawl on its own benchmark dataset — and runs 100% locally without cloud dependencies.

**Runs 100% locally, fully open:** Anti-bot / stealth bypass, BYO-proxy + rotation, and JS rendering (Cloudflare challenges, SPAs) all ship in the open core — one single ~8 MB Rust binary, ~6 MB RAM, no multi-service stack. Firecrawl's OSS self-host gates its stealth engine (`fire-engine`) behind a cloud-only flag, so self-hosted Firecrawl can't reach protected or JS-heavy sites; fastCRW's can.

**Faster + higher recall — on Firecrawl's own benchmark dataset:** truth-recall 63.74 % vs 56.04 %, median latency p50 ~1.9 s vs ~2.3 s. Flat pricing: 1 credit = 1 page (no 4× stealth surcharge, no billed-on-failure).

**Search backed by SearXNG — with a quality layer on top:** crw is not an alternative to SearXNG; it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content rather than SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arXiv / Semantic Scholar / Google Scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer — all open-source (AGPL) and self-hostable with configurable engines.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported via `CRW_BASE_URL`. Happy to adjust to your conventions — I maintain it and can provide free credits.

Because fastCRW exposes a Firecrawl-compatible API, the integration is a small additive diff (Firecrawl node untouched).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six fastCRW-powered web tools: Search, Scrape, Crawl, Crawl Status, Map, and Extract for enhanced web interaction.
* **Documentation**
  * Documented CRW tools and added `CRW_API_KEY` to the environment-variable configuration (with optional `CRW_BASE_URL`), including usage examples and error-handling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
