### PR TITLE
Add Xquik search tool

### DIFF
--- a/src/nodes/registry.ts
+++ b/src/nodes/registry.ts
@@ -18,6 +18,7 @@ import { tools as snowtracerTools } from './snowtracer/index';
 import { tools as stockTools } from './stock-price';
 import type { ToolCollection } from './types';
 import { tools as weatherTools } from './weather';
+import { tools as xquikTools } from './xquik';
 
 // Combined tools registry
 export const allTools: ToolCollection = {
@@ -30,6 +31,7 @@ export const allTools: ToolCollection = {
   ...imageGenerationTools,
   ...cognitiveTools,
   ...scienceTools,
+  ...xquikTools,
   crypto_price: cryptoPriceTool,
   trending_cryptos: trendingCryptosTool
 };

--- a/src/nodes/xquik/README.md
+++ b/src/nodes/xquik/README.md
@@ -1,0 +1,44 @@
+# Xquik Tool
+
+The Xquik tool lets AgentDock agents search public X posts through the Xquik API.
+
+## Configuration
+
+Set the API key before using the tool:
+
+```bash
+XQUIK_API_KEY=your_api_key_here
+```
+
+You can optionally override the API base URL:
+
+```bash
+XQUIK_BASE_URL=https://xquik.com/api/v1
+```
+
+## Tool
+
+### `xquik_search_posts`
+
+Search public X posts by keyword query, hashtag, status URL, or post ID.
+
+Parameters:
+
+- `query` (required): Search query, hashtag, status URL, or post ID
+- `queryType` (optional): `Latest` or `Top`, defaults to `Latest`
+- `limit` (optional): Maximum number of posts to return, defaults to `10`
+- `cursor` (optional): Pagination cursor from a previous Xquik response
+- `apiKey` (optional): Xquik API key for per-call overrides
+- `baseUrl` (optional): Xquik API base URL for per-call overrides
+
+Example:
+
+```typescript
+const result = await agent.executeTool('xquik_search_posts', {
+  query: 'AI agents',
+  limit: 5
+});
+```
+
+The tool returns formatted post text, author details, engagement counts, and a
+pagination cursor when more results are available.

--- a/src/nodes/xquik/README.md
+++ b/src/nodes/xquik/README.md
@@ -10,12 +10,6 @@ Set the API key before using the tool:
 XQUIK_API_KEY=your_api_key_here
 ```
 
-You can optionally override the API base URL:
-
-```bash
-XQUIK_BASE_URL=https://xquik.com/api/v1
-```
-
 ## Tool
 
 ### `xquik_search_posts`
@@ -28,8 +22,6 @@ Parameters:
 - `queryType` (optional): `Latest` or `Top`, defaults to `Latest`
 - `limit` (optional): Maximum number of posts to return, defaults to `10`
 - `cursor` (optional): Pagination cursor from a previous Xquik response
-- `apiKey` (optional): Xquik API key for per-call overrides
-- `baseUrl` (optional): Xquik API base URL for per-call overrides
 
 Example:
 

--- a/src/nodes/xquik/api.ts
+++ b/src/nodes/xquik/api.ts
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Xquik API client for public X post search.
+ */
+
+export interface XquikAuthor {
+  id?: string;
+  name?: string;
+  username?: string;
+  verified?: boolean;
+}
+
+export interface XquikPost {
+  id?: string;
+  text?: string;
+  created?: number;
+  created_at?: string;
+  createdAt?: string;
+  like_count?: number;
+  likeCount?: number;
+  retweet_count?: number;
+  retweetCount?: number;
+  reply_count?: number;
+  replyCount?: number;
+  quote_count?: number;
+  quoteCount?: number;
+  view_count?: number;
+  viewCount?: number;
+  bookmark_count?: number;
+  bookmarkCount?: number;
+  url?: string;
+  author?: XquikAuthor;
+}
+
+interface XquikErrorBody {
+  error?: string | { message?: string; code?: string; type?: string };
+  message?: string;
+}
+
+interface XquikSearchResponse {
+  tweets?: XquikPost[];
+  has_more?: boolean;
+  has_next_page?: boolean;
+  next_cursor?: string;
+  nextCursor?: string;
+}
+
+export interface XquikSearchResult {
+  posts: XquikPost[];
+  hasMore: boolean;
+  nextCursor?: string;
+}
+
+export interface XquikSearchOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  cursor?: string;
+  limit: number;
+  query: string;
+  queryType: 'Latest' | 'Top';
+}
+
+const DEFAULT_BASE_URL = 'https://xquik.com/api/v1';
+
+function resolveBaseUrl(baseUrl?: string): string {
+  return (baseUrl || process.env.XQUIK_BASE_URL || DEFAULT_BASE_URL).replace(
+    /\/+$/,
+    ''
+  );
+}
+
+function resolveApiKey(apiKey?: string): string {
+  const key = apiKey || process.env.XQUIK_API_KEY;
+  if (!key) {
+    throw new Error('XQUIK_API_KEY is not configured.');
+  }
+  return key;
+}
+
+function getErrorMessage(body: XquikErrorBody, status: number): string {
+  if (typeof body.error === 'object' && body.error?.message) {
+    return body.error.message;
+  }
+  if (typeof body.error === 'string') {
+    return body.message || body.error;
+  }
+  return body.message || `Xquik API returned HTTP ${status}`;
+}
+
+function normalizeErrorMessage(message: string, status: number): string {
+  if (status === 401) {
+    return 'Xquik API key is missing or invalid.';
+  }
+  if (status === 402) {
+    return 'Xquik returned payment required. Check your Xquik account access.';
+  }
+  if (status === 429) {
+    return 'Xquik rate limit reached. Try again later.';
+  }
+  return message;
+}
+
+export async function searchXquikPosts({
+  apiKey,
+  baseUrl,
+  cursor,
+  limit,
+  query,
+  queryType
+}: XquikSearchOptions): Promise<XquikSearchResult> {
+  const key = resolveApiKey(apiKey);
+  const url = new URL(`${resolveBaseUrl(baseUrl)}/x/tweets/search`);
+  url.searchParams.set('q', query);
+  url.searchParams.set('queryType', queryType);
+  url.searchParams.set('limit', String(limit));
+  if (cursor) {
+    url.searchParams.set('cursor', cursor);
+  }
+
+  const response = await fetch(url, {
+    headers: {
+      'X-Api-Key': key,
+      Accept: 'application/json'
+    },
+    cache: 'no-store'
+  });
+
+  const data = (await response.json()) as XquikSearchResponse | XquikErrorBody;
+
+  if (!response.ok) {
+    throw new Error(
+      normalizeErrorMessage(
+        getErrorMessage(data as XquikErrorBody, response.status),
+        response.status
+      )
+    );
+  }
+
+  const body = data as XquikSearchResponse;
+  return {
+    posts: Array.isArray(body.tweets) ? body.tweets : [],
+    hasMore: Boolean(body.has_more ?? body.has_next_page),
+    nextCursor: body.next_cursor ?? body.nextCursor
+  };
+}

--- a/src/nodes/xquik/api.ts
+++ b/src/nodes/xquik/api.ts
@@ -51,8 +51,6 @@ export interface XquikSearchResult {
 }
 
 export interface XquikSearchOptions {
-  apiKey?: string;
-  baseUrl?: string;
   cursor?: string;
   limit: number;
   query: string;
@@ -60,16 +58,10 @@ export interface XquikSearchOptions {
 }
 
 const DEFAULT_BASE_URL = 'https://xquik.com/api/v1';
+const REQUEST_TIMEOUT_MS = 15_000;
 
-function resolveBaseUrl(baseUrl?: string): string {
-  return (baseUrl || process.env.XQUIK_BASE_URL || DEFAULT_BASE_URL).replace(
-    /\/+$/,
-    ''
-  );
-}
-
-function resolveApiKey(apiKey?: string): string {
-  const key = apiKey || process.env.XQUIK_API_KEY;
+function resolveApiKey(): string {
+  const key = process.env.XQUIK_API_KEY;
   if (!key) {
     throw new Error('XQUIK_API_KEY is not configured.');
   }
@@ -99,16 +91,32 @@ function normalizeErrorMessage(message: string, status: number): string {
   return message;
 }
 
+async function readJsonResponse(
+  response: Response
+): Promise<XquikSearchResponse | XquikErrorBody> {
+  try {
+    return (await response.json()) as XquikSearchResponse | XquikErrorBody;
+  } catch {
+    if (!response.ok) {
+      throw new Error(
+        normalizeErrorMessage(
+          `Xquik API returned HTTP ${response.status}`,
+          response.status
+        )
+      );
+    }
+    throw new Error('Xquik returned an invalid JSON response.');
+  }
+}
+
 export async function searchXquikPosts({
-  apiKey,
-  baseUrl,
   cursor,
   limit,
   query,
   queryType
 }: XquikSearchOptions): Promise<XquikSearchResult> {
-  const key = resolveApiKey(apiKey);
-  const url = new URL(`${resolveBaseUrl(baseUrl)}/x/tweets/search`);
+  const key = resolveApiKey();
+  const url = new URL(`${DEFAULT_BASE_URL}/x/tweets/search`);
   url.searchParams.set('q', query);
   url.searchParams.set('queryType', queryType);
   url.searchParams.set('limit', String(limit));
@@ -116,29 +124,42 @@ export async function searchXquikPosts({
     url.searchParams.set('cursor', cursor);
   }
 
-  const response = await fetch(url, {
-    headers: {
-      'X-Api-Key': key,
-      Accept: 'application/json'
-    },
-    cache: 'no-store'
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-  const data = (await response.json()) as XquikSearchResponse | XquikErrorBody;
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'X-Api-Key': key,
+        Accept: 'application/json'
+      },
+      cache: 'no-store',
+      signal: controller.signal
+    });
 
-  if (!response.ok) {
-    throw new Error(
-      normalizeErrorMessage(
-        getErrorMessage(data as XquikErrorBody, response.status),
-        response.status
-      )
-    );
+    const data = await readJsonResponse(response);
+
+    if (!response.ok) {
+      throw new Error(
+        normalizeErrorMessage(
+          getErrorMessage(data as XquikErrorBody, response.status),
+          response.status
+        )
+      );
+    }
+
+    const body = data as XquikSearchResponse;
+    return {
+      posts: Array.isArray(body.tweets) ? body.tweets : [],
+      hasMore: Boolean(body.has_more ?? body.has_next_page),
+      nextCursor: body.next_cursor ?? body.nextCursor
+    };
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('Xquik request timed out. Try again later.');
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
   }
-
-  const body = data as XquikSearchResponse;
-  return {
-    posts: Array.isArray(body.tweets) ? body.tweets : [],
-    hasMore: Boolean(body.has_more ?? body.has_next_page),
-    nextCursor: body.next_cursor ?? body.nextCursor
-  };
 }

--- a/src/nodes/xquik/components.ts
+++ b/src/nodes/xquik/components.ts
@@ -26,14 +26,20 @@ function numberValue(value: number | undefined): number {
 function getPostUrl(post: XquikPost): string | undefined {
   if (post.url) return post.url;
   if (post.id && post.author?.username) {
-    return `https://x.com/${post.author.username}/status/${post.id}`;
+    return `https://x.com/${encodeURIComponent(post.author.username)}/status/${
+      post.id
+    }`;
   }
   return undefined;
 }
 
 function getCreatedLabel(post: XquikPost): string | undefined {
   if (typeof post.created === 'number') {
-    return new Date(post.created * 1000).toISOString();
+    const timestamp = post.created * 1000;
+    const date = new Date(timestamp);
+    if (Number.isFinite(timestamp) && Number.isFinite(date.getTime())) {
+      return date.toISOString();
+    }
   }
   return post.created_at ?? post.createdAt;
 }

--- a/src/nodes/xquik/components.ts
+++ b/src/nodes/xquik/components.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Output formatting for Xquik search results.
+ */
+
+import {
+  cleanText,
+  createToolResult,
+  formatBold,
+  formatHeader,
+  formatLink,
+  joinSections
+} from '@/lib/utils/markdown-utils';
+import type { XquikPost } from './api';
+
+interface XquikSearchResultsProps {
+  hasMore: boolean;
+  nextCursor?: string;
+  posts: XquikPost[];
+  query: string;
+}
+
+function numberValue(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function getPostUrl(post: XquikPost): string | undefined {
+  if (post.url) return post.url;
+  if (post.id && post.author?.username) {
+    return `https://x.com/${post.author.username}/status/${post.id}`;
+  }
+  return undefined;
+}
+
+function getCreatedLabel(post: XquikPost): string | undefined {
+  if (typeof post.created === 'number') {
+    return new Date(post.created * 1000).toISOString();
+  }
+  return post.created_at ?? post.createdAt;
+}
+
+function formatPost(post: XquikPost, index: number): string {
+  const username = post.author?.username ? `@${post.author.username}` : 'X';
+  const displayName = post.author?.name
+    ? `${post.author.name} (${username})`
+    : username;
+  const text = cleanText(post.text || 'No text available.');
+  const created = getCreatedLabel(post);
+  const url = getPostUrl(post);
+  const metrics = [
+    `${numberValue(post.like_count ?? post.likeCount)} likes`,
+    `${numberValue(post.retweet_count ?? post.retweetCount)} reposts`,
+    `${numberValue(post.reply_count ?? post.replyCount)} replies`
+  ].join(', ');
+  const sourceLink = url ? ` ${formatLink('Open post', url)}` : '';
+  const createdLine = created ? `\n${created}` : '';
+
+  return `${formatBold(`${index + 1}. ${displayName}`)}${sourceLink}${createdLine}\n${text}\n${metrics}`;
+}
+
+export function XquikSearchResults(props: XquikSearchResultsProps) {
+  const header = formatHeader(`Xquik Results for "${props.query}"`);
+
+  if (props.posts.length === 0) {
+    return createToolResult(
+      'xquik_search_results',
+      joinSections(header, 'No posts found.')
+    );
+  }
+
+  const postSections = props.posts.map(formatPost).join('\n\n');
+  const pagination = props.hasMore
+    ? `More results are available with cursor: ${props.nextCursor || 'available'}`
+    : '';
+
+  return createToolResult(
+    'xquik_search_results',
+    joinSections(header, postSections, pagination)
+  );
+}

--- a/src/nodes/xquik/index.ts
+++ b/src/nodes/xquik/index.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Xquik tool implementation for searching public X posts.
+ */
+
+import { LogCategory, logger } from 'agentdock-core';
+import { z } from 'zod';
+
+import {
+  createToolResult,
+  formatErrorMessage
+} from '@/lib/utils/markdown-utils';
+import type { Tool } from '../types';
+import { searchXquikPosts } from './api';
+import { XquikSearchResults } from './components';
+
+const xquikSearchPostsSchema = z.object({
+  query: z.string().describe('X search query, hashtag, status URL, or post ID'),
+  queryType: z
+    .enum(['Latest', 'Top'])
+    .optional()
+    .default('Latest')
+    .describe('Sort order for results'),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .default(10)
+    .describe('Maximum number of posts to return'),
+  cursor: z.string().optional().describe('Pagination cursor from Xquik'),
+  apiKey: z
+    .string()
+    .optional()
+    .describe('Optional Xquik API key, otherwise uses XQUIK_API_KEY'),
+  baseUrl: z.string().url().optional().describe('Optional Xquik API base URL')
+});
+
+type XquikSearchPostsParams = z.infer<typeof xquikSearchPostsSchema>;
+
+export const xquikSearchPostsTool: Tool = {
+  name: 'xquik_search_posts',
+  description: 'Search public X posts with Xquik',
+  parameters: xquikSearchPostsSchema,
+  async execute({
+    apiKey,
+    baseUrl,
+    cursor,
+    limit = 10,
+    query,
+    queryType = 'Latest'
+  }: XquikSearchPostsParams) {
+    logger.debug(LogCategory.NODE, '[Xquik]', 'Searching public X posts', {
+      limit,
+      queryType
+    });
+
+    try {
+      const trimmedQuery = query.trim();
+      if (!trimmedQuery) {
+        return createToolResult(
+          'xquik_search_error',
+          formatErrorMessage('Error', 'Please provide a non-empty query.')
+        );
+      }
+
+      const results = await searchXquikPosts({
+        apiKey,
+        baseUrl,
+        cursor,
+        limit,
+        query: trimmedQuery,
+        queryType
+      });
+
+      return XquikSearchResults({
+        hasMore: results.hasMore,
+        nextCursor: results.nextCursor,
+        posts: results.posts,
+        query: trimmedQuery
+      });
+    } catch (error: unknown) {
+      logger.error(LogCategory.NODE, '[Xquik]', 'Search execution error', {
+        error
+      });
+
+      const message = error instanceof Error ? error.message : String(error);
+      return createToolResult(
+        'xquik_search_error',
+        formatErrorMessage('Error', message)
+      );
+    }
+  }
+};
+
+export const tools = {
+  xquik_search_posts: xquikSearchPostsTool
+};

--- a/src/nodes/xquik/index.ts
+++ b/src/nodes/xquik/index.ts
@@ -30,10 +30,10 @@ const xquikSearchPostsSchema = z.object({
     .describe('Maximum number of posts to return'),
   cursor: z.string().optional().describe('Pagination cursor from Xquik'),
   apiKey: z
-    .string()
+    .never()
     .optional()
-    .describe('Optional Xquik API key, otherwise uses XQUIK_API_KEY'),
-  baseUrl: z.string().url().optional().describe('Optional Xquik API base URL')
+    .describe('Configure XQUIK_API_KEY on the server'),
+  baseUrl: z.never().optional().describe('Endpoint overrides are not supported')
 });
 
 type XquikSearchPostsParams = z.infer<typeof xquikSearchPostsSchema>;
@@ -43,8 +43,6 @@ export const xquikSearchPostsTool: Tool = {
   description: 'Search public X posts with Xquik',
   parameters: xquikSearchPostsSchema,
   async execute({
-    apiKey,
-    baseUrl,
     cursor,
     limit = 10,
     query,
@@ -65,8 +63,6 @@ export const xquikSearchPostsTool: Tool = {
       }
 
       const results = await searchXquikPosts({
-        apiKey,
-        baseUrl,
         cursor,
         limit,
         query: trimmedQuery,


### PR DESCRIPTION
## Summary

- Add `xquik_search_posts` for searching public X posts through the Xquik API.
- Register the tool in the AgentDock tool registry.
- Document `XQUIK_API_KEY`, optional `XQUIK_BASE_URL`, parameters, and example usage.

## Validation

- `git diff --check`
- `pnpm dlx prettier@3.5.3 --check src/nodes/registry.ts src/nodes/xquik/api.ts src/nodes/xquik/components.ts src/nodes/xquik/index.ts src/nodes/xquik/README.md`
- TypeScript transpile pass over changed TypeScript files using TypeScript 5.7.3

Full local dependency install could not complete because local Node 26 cannot build the target's `better-sqlite3` dependency. A project-wide `tsc` run after the partial install also stopped on missing generated templates and optional packages outside this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Xquik integration to search public X posts with customizable query, query type, limits, and pagination.
  * Search results now show post content, author details, engagement metrics, timestamps, and an optional “Open post” link.
  * API key–based access is required for the Xquik search tool.
* **Documentation**
  * Added setup and usage documentation for the Xquik tool, including input options and example usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

<!-- mesa-description-start -->
## TL;DR

Added the `xquik_search_posts` tool to AgentDock to enable searching public X posts via the Xquik API.

## Why we made these changes

To allow agents to programmatically search and retrieve public posts from X (formerly Twitter), including author information and engagement metrics, expanding the platform's data collection capabilities.

## What changed?

- **`src/nodes/registry.ts`**: Integrated `xquikTools` into the `allTools` registry to make it available to AgentDock.
- **`src/nodes/xquik/api.ts`**: Implemented the Xquik API client, including TypeScript interfaces, validation, error normalization, and the `searchXquikPosts` fetch function.
- **`src/nodes/xquik/components.ts`**: Created Markdown rendering components (`XquikSearchResults`) and utilities to format post details, timestamps, and engagement metrics.
- **`src/nodes/xquik/index.ts`**: Defined the tool module with the `xquikSearchPostsSchema` for input validation and exported the `xquikSearchPostsTool`.
- **`src/nodes/xquik/README.md`**: Added setup documentation detailing required (`XQUIK_API_KEY`) and optional (`XQUIK_BASE_URL`) configuration and tool usage.

## Validation

- Ran `git diff --check`
- Verified file formatting using `pnpm dlx prettier@3.5.3 --check` on all modified files
- Performed a TypeScript transpile pass over changed TypeScript files using TypeScript 5.7.3
- *Note: Full local dependency install bypassed due to Node 26 compatibility issues with `better-sqlite3`.*

<sup>_Description generated by Mesa. [Update settings](https://wrangler.app.mesa.dev/AgentDock/settings/pull-requests)_</sup>
<!-- mesa-description-end -->